### PR TITLE
Editing readme to fix wrong tagged config

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ composer require omakei/laravel-nextsms
 You can publish the config file with:
 
 ```bash
-php artisan vendor:publish --tag="laravel-nextsms-config"
+php artisan vendor:publish --tag="nextsms-config"
 ```
 
 The following keys must be available in your `.env` file:


### PR DESCRIPTION
The previously published config file command did not work, the reason was the wrong tag used. I have modified the documentation so that the command points to the right tag for publishing a config file.